### PR TITLE
Add JobController default status test

### DIFF
--- a/backend-springboot/src/test/java/com/example/jobjet/controller/JobControllerTest.java
+++ b/backend-springboot/src/test/java/com/example/jobjet/controller/JobControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.jobjet.controller;
+
+import com.example.jobjet.model.Job;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class JobControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void whenPostJobWithoutStatus_thenStatusDefaultsToChoDuyet() throws Exception {
+        Job job = new Job();
+        job.setTitle("Test Job");
+        job.setDescription("Test Description");
+        job.setCompany("Test Company");
+        job.setLocation("Test Location");
+
+        mockMvc.perform(post("/api/jobs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(job)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("Chờ duyệt"));
+    }
+}


### PR DESCRIPTION
## Summary
- test JobController POST assigns default status "Chờ duyệt" when status missing

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689632425b60832aa3bc9b0050c9992a